### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Test Go Scripts
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/btassone/goverman/security/code-scanning/1](https://github.com/btassone/goverman/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Based on the workflow's steps, it primarily involves checking out the repository and running tests, so `contents: read` is sufficient. No write permissions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
